### PR TITLE
Bug fix to handle pastes in the middle of bidtree

### DIFF
--- a/bml.py
+++ b/bml.py
@@ -150,7 +150,8 @@ def create_bidtree(text):
         
     # breaks when no more PASTE in bidtable
     while True:
-        paste = re.search(r'^(\s*)#\s*PASTE\s+(\S+)\s*(.*)\n?', text, flags=re.MULTILINE)
+        paste = re.search(r'^(\s*)#\s*PASTE\s+(\S+)[^\S\n]*(.*)\n?', text, flags=re.MULTILINE)
+
         if not paste:
             break
         indentation = paste.group(1)
@@ -161,7 +162,7 @@ def create_bidtree(text):
         lines = lines.split('\n')
         for l in range(len(lines)):
             lines[l] = indentation + lines[l]
-        text = text[:paste.start()] + '\n'.join(lines) + text[paste.end():]
+        text = text[:paste.start()] + '\n'.join(lines) + '\n' + text[paste.end():]
         
     hide = re.search(r'^\s*#\s*HIDE\s*\n', text, flags=re.MULTILINE)
     if hide:


### PR DESCRIPTION
Needed this fix for the case where the paste was in the middle of a bidding tree rather than at the end.  In this scenario it would not be able to detect the end of the #PASTE block correctly.  I tested that this change does not impact the case where the #PASTE block is at the end of the biddingtree as well as the scenario where there are some additional replacements of form #ENDPASTE \foo=bar